### PR TITLE
Use different example bootswatch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Here's approximately how your `application.css.scss` file should look like, cons
     @import "bootstrap-responsive";
 
     // And finally bootswatch style itself
-    @import "bootswatch/journal/bootswatch";
+    @import "bootswatch/cerulean/bootswatch";
 
     // Whatever application styles you have go last
     @import "base";


### PR DESCRIPTION
Thought 'journal' was something specific to the code and not a bootswatch title.  Changed to 'cerulean' which is perhaps more indicative of a bootswatch title - a color name!
