### PR TITLE
Extend cyborg's gradient background to full windows height

### DIFF
--- a/vendor/assets/stylesheets/bootswatch/cyborg/_bootswatch.scss
+++ b/vendor/assets/stylesheets/bootswatch/cyborg/_bootswatch.scss
@@ -40,7 +40,12 @@ blockquote {
 // SCAFFOLDING
 // -----------------------------------------------------
 
+html {
+	min-height: 100%;
+}
+
 body {
+	min-height: 100%;
 	@include gradient-vertical ($bodyBackground, #252A30);
 }
 


### PR DESCRIPTION
Hi,

I've noticed that the gradient background in the Cyborg theme didn't really work (at least for Chrome|Safari). See for yourself: http://db.tt/eXLpdDkq. There's been a fix for this in the bootswatch repo a couple months ago: https://github.com/thomaspark/bootswatch/commit/9369f5b1792dd0d64d0d94311944922e009f0974

Please note that I only added the min-height directive according to the bootswatch.less file. This extended the gradient to full window height.

Regards,
Mike
