### PR TITLE
Fixed buggy calls to bootstrap-sass

### DIFF
--- a/vendor/assets/stylesheets/bootswatch/cerulean/_bootswatch.scss
+++ b/vendor/assets/stylesheets/bootswatch/cerulean/_bootswatch.scss
@@ -15,7 +15,7 @@
 // -----------------------------------------------------
 
 .navbar-inner {
-  @include gradient-vertical-three-colors($navbarBackground, $navbarBackground, 90%, $navbarBackgroundHighlight);
+  @include gradient-vertical-three-colors($navbarBackground, $navbarBackground, .9, $navbarBackgroundHighlight);
 }
 
 .navbar .nav .active > a,
@@ -54,7 +54,7 @@
 // -----------------------------------------------------
 
 .btn {
-  @include gradient-vertical-three-colors($white, $white, 5%, darken($white, 0%));
+  @include gradient-vertical-three-colors($white, $white, .05, darken($white, 0%));
   $shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
   @include box-shadow($shadow);
 


### PR DESCRIPTION
There were 2 calls to gradient-vertical-three-colors where a value was given as a % when bootstrap-sass seems to prefer a decimal (i.e. 90% should be 0.9)

This was causing an error for me: '9000%*% is not a valid css.....'

I was using bootstrap-sass version 2.1.0.0

The bug exists in some other swatches as well.
