### PR TITLE
Fix simplex/_bootswatch.scss for box-shadow error

### DIFF
--- a/vendor/assets/stylesheets/bootswatch/simplex/_bootswatch.scss
+++ b/vendor/assets/stylesheets/bootswatch/simplex/_bootswatch.scss
@@ -137,7 +137,7 @@ div.subnav {
 	font-family: $headingsFontFamily;
 
 	&.subnav-fixed {
-		@include box-shadow(inset 0 5px #fff, $boxShadow);
+		@include box-shadow(#{inset 0 5px #fff, $boxShadow});
 	}
 
 	.nav > li > a {
@@ -308,7 +308,7 @@ div.subnav {
 .breadcrumb {
 	background-color: $white;
 	border: 0px solid transparent;
-	@include box-shadow($boxShadow, -1px -1px 0 rgba(0, 0, 0, 0.1));
+	@include box-shadow(#{$boxShadow, -1px -1px 0 rgba(0, 0, 0, 0.1)});
 
 	li {
 		padding-top: 2px;
@@ -416,13 +416,13 @@ i[class^="icon-"]{
 }
 
 .well {
-	@include box-shadow($boxShadow, -1px -1px 0 rgba(0, 0, 0, 0.1));
+	@include box-shadow(#{$boxShadow, -1px -1px 0 rgba(0, 0, 0, 0.1)});
 	border: none;
 }
 
 .hero-unit {
 	background-color: $navbarBackground;
-	@include box-shadow($boxShadow, -1px -1px 0 rgba(0, 0, 0, 0.1));
+	@include box-shadow(#{$boxShadow, -1px -1px 0 rgba(0, 0, 0, 0.1)});
 }
 
 .thumbnail {


### PR DESCRIPTION
I had this error when using the simplex template with bootswatch-rails 0.3.1, rails 3.2.11 and ruby 1.9.2:

```
Mixin box-shadow takes 1 argument but 2 were passed. 
```

The reason was that "to pass multiple values to the Bootstrap mixins, you must escape the values or else the Sass parser will choke on the commas" (https://github.com/thomas-mcdonald/bootstrap-sass#passing-multiple-values-to-mixins).
