### PR TITLE
Remove call to 'e' method in amelia bootswatch

### DIFF
--- a/vendor/assets/stylesheets/bootswatch/amelia/_bootswatch.scss
+++ b/vendor/assets/stylesheets/bootswatch/amelia/_bootswatch.scss
@@ -382,7 +382,7 @@ div.subnav {
   // IE 7 + 8 can't handle box-shadow to show active, so we darken a bit ourselves
   &:active,
   &.active {
-    background-color: darken($color, 15%) e("\9");
+    background-color: darken($color, 15%);
   }
 }
 


### PR DESCRIPTION
The method call to 'e' was causing a compilation error for me.  From what I've read, it's probably carryover from the less source and isn't necessary.  Thanks!
