### PR TITLE
Bugfix: use boostrap-sass "~> 2"

### DIFF
--- a/bootswatch-rails.gemspec
+++ b/bootswatch-rails.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://github.com/maxim/bootswatch-rails"
 
   gem.add_dependency 'railties', '>= 3.1'
+  gem.add_dependency 'bootstrap-sass', '~> 2'
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Bugfix: bootswatch-rails' dependency on bootstrap-sass was not named in the gemspec. This omission is critical because bootswatch-rails no longer works with the head version of bootstrap-sass: it relies on at least one mixin (buttonBackground) which was removed between bootstrap-sass version 2 and 3.
