### PR TITLE
fix syntax error in darkly and flatly

### DIFF
--- a/vendor/assets/stylesheets/bootswatch/darkly/_variables.scss
+++ b/vendor/assets/stylesheets/bootswatch/darkly/_variables.scss
@@ -463,7 +463,7 @@ $pagination-active-bg:                 lighten($brand-success, 6%) !default;
 $pagination-active-border:             transparent !default;
 
 $pagination-disabled-color:            #fff !default;
-$pagination-disabled-bg:               darken($brand-success, 15%) !default;;
+$pagination-disabled-bg:               darken($brand-success, 15%) !default;
 $pagination-disabled-border:           transparent !default;
 
 

--- a/vendor/assets/stylesheets/bootswatch/flatly/_variables.scss
+++ b/vendor/assets/stylesheets/bootswatch/flatly/_variables.scss
@@ -463,7 +463,7 @@ $pagination-active-bg:                 darken($brand-success, 15%) !default;
 $pagination-active-border:             transparent !default;
 
 $pagination-disabled-color:            $gray-lighter !default;
-$pagination-disabled-bg:               lighten($brand-success, 15%) !default;;
+$pagination-disabled-bg:               lighten($brand-success, 15%) !default;
 $pagination-disabled-border:           transparent !default;
 
 


### PR DESCRIPTION
Double semicolons in darkly and flatly were causing syntax errors with libsass.
